### PR TITLE
fix issue #16 : Better Exception on FixerApi.php provider

### DIFF
--- a/src/Exception/InvalidCurrencyException.php
+++ b/src/Exception/InvalidCurrencyException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: slavielle
+ * Date: 29/11/17
+ * Time: 09:30
+ */
+
+namespace CurrencyConverter\Exception;
+
+
+class InvalidCurrencyException extends InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Exception/UnsupportedCurrencyException.php
+++ b/src/Exception/UnsupportedCurrencyException.php
@@ -9,6 +9,6 @@
 namespace CurrencyConverter\Exception;
 
 
-class InvalidCurrencyException extends InvalidArgumentException implements ExceptionInterface
+class UnsupportedCurrencyException extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnsupportedCurrencyException.php
+++ b/src/Exception/UnsupportedCurrencyException.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: slavielle
- * Date: 29/11/17
- * Time: 09:30
- */
 
 namespace CurrencyConverter\Exception;
-
 
 class UnsupportedCurrencyException extends InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Provider/FixerApi.php
+++ b/src/Provider/FixerApi.php
@@ -2,7 +2,7 @@
 
 namespace CurrencyConverter\Provider;
 
-use CurrencyConverter\Exception\InvalidCurrencyException;
+use CurrencyConverter\Exception\UnsupportedCurrencyException;
 use GuzzleHttp\Client;
 
 /**
@@ -45,7 +45,7 @@ class FixerApi implements ProviderInterface
         $result = json_decode($this->httpClient->get($path)->getBody(), true);
 
         if (!isset($result['rates'][$toCurrency])) {
-            throw new InvalidCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
+            throw new UnsupportedCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
         }
 
         return $result['rates'][$toCurrency];

--- a/src/Provider/FixerApi.php
+++ b/src/Provider/FixerApi.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace CurrencyConverter\Provider;
 
+use CurrencyConverter\Exception\InvalidCurrencyException;
 use GuzzleHttp\Client;
 
 /**
@@ -41,6 +43,11 @@ class FixerApi implements ProviderInterface
             $fromCurrency
         );
         $result = json_decode($this->httpClient->get($path)->getBody(), true);
+
+        if (!isset($result['rates'][$toCurrency])) {
+            throw new InvalidCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
+        }
+
         return $result['rates'][$toCurrency];
     }
 }

--- a/tests/CurrencyConverterTest/Provider/FixerApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FixerApiTest.php
@@ -14,7 +14,7 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('getBody')
             ->will($this->returnValue(
-                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-02","rates":{"USD":1.1645}}','r'))
+                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-02","rates":{"USD":1.1645}}', 'r'))
             ));
         $httpClient = $this->getMock(Client::class);
         $httpClient
@@ -30,4 +30,34 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
             (new FixerApi($httpClient))->getRate('EUR', 'USD')
         );
     }
+
+    public function testGetUnavailableRate()
+    {
+        $response = $this->getMock(ResponseInterface::class);
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue(
+                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-28","rates":{}}', 'r'))
+            ));
+        $httpClient = $this->getMock(Client::class);
+        $httpClient
+            ->expects($this->once())
+            ->method('__call')
+            ->with(
+                'get',
+                [FixerApi::FIXER_API_BASEPATH . '?symbols=XXX&base=EUR']
+            )
+            ->will($this->returnValue($response));
+
+        $expectedExceptionThrown = FALSE;
+        try {
+            (new FixerApi($httpClient))->getRate('EUR', 'XXX');
+        } catch (\Exception $e) {
+            $expectedExceptionThrown = TRUE;
+        }
+        $this->assertTrue($expectedExceptionThrown);
+    }
+
+
 }

--- a/tests/CurrencyConverterTest/Provider/FixerApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FixerApiTest.php
@@ -52,14 +52,8 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($response));
 
-        $expectedExceptionThrown = false;
-        try {
-            (new FixerApi($httpClient))->getRate('EUR', 'XXX');
-        } catch (UnsupportedCurrencyException $e) {
-            $expectedExceptionThrown = true;
-        }
-        $this->assertTrue($expectedExceptionThrown);
+        $this->setExpectedException(UnsupportedCurrencyException::class);
+        (new FixerApi($httpClient))->getRate('EUR', 'XXX');
     }
-
-
+    
 }

--- a/tests/CurrencyConverterTest/Provider/FixerApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FixerApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CurrencyConverter\Provider;
 
 use GuzzleHttp\Client;
@@ -50,11 +51,11 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($response));
 
-        $expectedExceptionThrown = FALSE;
+        $expectedExceptionThrown = false;
         try {
             (new FixerApi($httpClient))->getRate('EUR', 'XXX');
         } catch (\Exception $e) {
-            $expectedExceptionThrown = TRUE;
+            $expectedExceptionThrown = true;
         }
         $this->assertTrue($expectedExceptionThrown);
     }

--- a/tests/CurrencyConverterTest/Provider/FixerApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FixerApiTest.php
@@ -2,6 +2,7 @@
 
 namespace CurrencyConverter\Provider;
 
+use CurrencyConverter\Exception\UnsupportedCurrencyException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\ResponseInterface;
@@ -54,7 +55,7 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
         $expectedExceptionThrown = false;
         try {
             (new FixerApi($httpClient))->getRate('EUR', 'XXX');
-        } catch (\Exception $e) {
+        } catch (UnsupportedCurrencyException $e) {
             $expectedExceptionThrown = true;
         }
         $this->assertTrue($expectedExceptionThrown);


### PR DESCRIPTION
PHPUnit 4.* seems not having expectException available. So I tested InvalidCurrencyException the old way :)