### PR TITLE
Rename file to conform to psr-4 autoloading standard

### DIFF
--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,6 @@
+<?php
+namespace CurrencyConverter\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}


### PR DESCRIPTION
This pull request renames the RunTimeException.php file to RuntimeException.php to conform to the psr-4 php standard.

Currently composer gives the below deprecated notice:

```
Deprecation Notice: Class CurrencyConverter\Exception\RuntimeException located in ./vendor/ujjwal/currency-converter/src/Exception/RunTimeException.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```

This fixes the above issue