### PR TITLE
Add frankfurter api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "ext-curl": "*",
         "zendframework/zend-cache": "2.*",
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "4.* || 5.*"
     },
     "suggest": {
         "ext-curl": "Using the rate provider for getting the rate from fixer.io using curl extension",

--- a/examples/simple-frankfurter.php
+++ b/examples/simple-frankfurter.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+$converter = new CurrencyConverter\CurrencyConverter;
+$converter->setRateProvider(new \CurrencyConverter\Provider\FrankfurterApi());
+
+echo $converter->convert('USD', 'EUR');

--- a/src/Provider/AbstractFixerApi.php
+++ b/src/Provider/AbstractFixerApi.php
@@ -1,0 +1,102 @@
+<?php
+namespace CurrencyConverter\Provider;
+
+use CurrencyConverter\Exception\UnsupportedCurrencyException;
+use GuzzleHttp\Client;
+
+abstract class AbstractFixerApi implements ProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string|null
+     */
+    protected $accessKey = null;
+
+    /**
+     * @var Client
+     */
+    protected $httpClient;
+
+    /**
+     * @var bool
+     */
+    protected $useHttps = false;
+
+    /**
+     * @param string $basePath
+     * @return AbstractFixerApi
+     */
+    public function setBasePath($basePath)
+    {
+        $this->basePath = (string) $basePath;
+        return $this;
+    }
+
+    /**
+     * @param string|null $accessKey
+     * @return AbstractFixerApi
+     */
+    public function setAccessKey($accessKey)
+    {
+        $this->accessKey = $accessKey;
+        return $this;
+    }
+
+    /**
+     * @param Client|null $httpClient
+     * @return AbstractFixerApi
+     */
+    public function setHttpClient(Client $httpClient = null)
+    {
+        $this->httpClient = $httpClient;
+        return $this;
+    }
+
+    /**
+     * @return Client
+     */
+    protected function getHttpClient()
+    {
+        if ($this->httpClient === null) {
+            $this->httpClient = new Client();
+        }
+        return $this->httpClient;
+    }
+
+    /**
+     * @param bool $useHttps
+     * @return AbstractFixerApi
+     */
+    public function setUseHttps($useHttps)
+    {
+        $this->useHttps = (boolean) $useHttps;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRate($fromCurrency, $toCurrency)
+    {
+        $params = [];
+        if ($this->accessKey !== null) {
+            $params['access_key'] = $this->accessKey;
+        }
+        $params['symbols'] = $toCurrency;
+        $params['base'] = $fromCurrency;
+
+        $path = ($this->useHttps ? 'https://' : 'http://') . $this->basePath . '?' . http_build_query($params);
+
+        $result = json_decode($this->getHttpClient()->get($path)->getBody(), true);
+
+        if (!isset($result['rates'][$toCurrency])) {
+            throw new UnsupportedCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
+        }
+
+        return $result['rates'][$toCurrency];
+    }
+}

--- a/src/Provider/ExchangeRatesIo.php
+++ b/src/Provider/ExchangeRatesIo.php
@@ -1,51 +1,25 @@
 <?php
 namespace CurrencyConverter\Provider;
 
-use CurrencyConverter\Exception\UnsupportedCurrencyException;
 use GuzzleHttp\Client;
 
 /**
  * Get exchange rates from https://exchangeratesapi.io/
  */
-class ExchangeRatesIo implements ProviderInterface
+class ExchangeRatesIo extends AbstractFixerApi
 {
-    /**
-     * Base url of fixer api
-     *
-     * @var string
-     */
-    const EXCHANGERATESIO_API_BASEPATH = 'https://api.exchangeratesapi.io/latest';
+    const EXCHANGERATESIO_API_BASEPATH = 'api.exchangeratesapi.io/latest';
 
     /**
-     * @var Client
-     */
-    protected $httpClient;
-
-    /**
-     * FixerApi constructor.
      * @param Client|null $httpClient
      */
     public function __construct(Client $httpClient = null)
     {
-        $this->httpClient = $httpClient ?: new Client();
-    }
+        $this->setBasePath(self::EXCHANGERATESIO_API_BASEPATH);
+        $this->setUseHttps(true);
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRate($fromCurrency, $toCurrency)
-    {
-        $path = sprintf(
-            self::EXCHANGERATESIO_API_BASEPATH . '?symbols=%s&base=%s',
-            $toCurrency,
-            $fromCurrency
-        );
-        $result = json_decode($this->httpClient->get($path)->getBody(), true);
-
-        if (!isset($result['rates'][$toCurrency])) {
-            throw new UnsupportedCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
+        if ($httpClient !== null) {
+            $this->setHttpClient($httpClient);
         }
-
-        return $result['rates'][$toCurrency];
     }
 }

--- a/src/Provider/FixerApi.php
+++ b/src/Provider/FixerApi.php
@@ -1,15 +1,12 @@
 <?php
-
 namespace CurrencyConverter\Provider;
 
-use CurrencyConverter\Exception\UnsupportedCurrencyException;
 use GuzzleHttp\Client;
 
 /**
  * Fetch rates from https://fixer.io
- *
  */
-class FixerApi implements ProviderInterface
+class FixerApi extends AbstractFixerApi
 {
     /**
      * Base url of fixer api
@@ -19,54 +16,20 @@ class FixerApi implements ProviderInterface
     const FIXER_API_BASEPATH = 'data.fixer.io/api/latest';
 
     /**
-     * The fixer access key
-     *
-     * @var string
-     */
-    protected $accessKey;
-
-    /**
-     * @var Client
-     */
-    protected $httpClient;
-
-    /**
-     * Flag to switch http(s) usage. required as fixer.io enables https api endpoints for paid accounts only
-     * @var bool
-     */
-    protected $useHttps = false;
-
-    /**
      * FixerApi constructor.
+     *
      * @param string $accessKey
      * @param Client|null $httpClient
      * @param bool $useHttps defaults to false
      */
     public function __construct($accessKey, Client $httpClient = null, $useHttps = false)
     {
-        $this->accessKey = $accessKey;
-        $this->httpClient = $httpClient ?: new Client();
-        $this->useHttps = (bool)$useHttps;
-    }
+        $this->setAccessKey($accessKey);
+        $this->setUseHttps($useHttps);
+        $this->setBasePath(self::FIXER_API_BASEPATH);
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRate($fromCurrency, $toCurrency)
-    {
-        $path = sprintf(
-            '%s' . self::FIXER_API_BASEPATH . '?access_key=%s&symbols=%s&base=%s',
-            ($this->useHttps) ? 'https://' : 'http://',
-            $this->accessKey,
-            $toCurrency,
-            $fromCurrency
-        );
-        $result = json_decode($this->httpClient->get($path)->getBody(), true);
-
-        if (!isset($result['rates'][$toCurrency])) {
-            throw new UnsupportedCurrencyException(sprintf('Undefined rate for "%s" currency.', $toCurrency));
+        if ($httpClient !== null) {
+            $this->setHttpClient($httpClient);
         }
-
-        return $result['rates'][$toCurrency];
     }
 }

--- a/src/Provider/FrankfurterApi.php
+++ b/src/Provider/FrankfurterApi.php
@@ -1,0 +1,21 @@
+<?php
+namespace CurrencyConverter\Provider;
+
+/**
+ * Frankfurter currency api
+ * https://www.frankfurter.app/
+ */
+class FrankfurterApi extends AbstractFixerApi
+{
+    const DEFAULT_BASEPATH = 'api.frankfurter.app/latest';
+
+    /**
+     * @param string $basePath
+     * @param bool $useHttps
+     */
+    public function __construct($basePath = self::DEFAULT_BASEPATH, $useHttps = true)
+    {
+        $this->setBasePath($basePath);
+        $this->setUseHttps($useHttps);
+    }
+}

--- a/tests/CurrencyConverterTest/Provider/ExchangeRatesIoTest.php
+++ b/tests/CurrencyConverterTest/Provider/ExchangeRatesIoTest.php
@@ -20,11 +20,8 @@ class ExchangeRatesIoTest extends \PHPUnit_Framework_TestCase
         $httpClient = $this->getMock(Client::class);
         $httpClient
             ->expects($this->once())
-            ->method('__call')
-            ->with(
-                'get',
-                [ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=USD&base=EUR']
-            )
+            ->method('get')
+            ->with(ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=USD&base=EUR')
             ->will($this->returnValue($response));
         $this->assertEquals(
             1.1645,
@@ -44,11 +41,8 @@ class ExchangeRatesIoTest extends \PHPUnit_Framework_TestCase
         $httpClient = $this->getMock(Client::class);
         $httpClient
             ->expects($this->once())
-            ->method('__call')
-            ->with(
-                'get',
-                [ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=XXX&base=EUR']
-            )
+            ->method('get')
+            ->with(ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=XXX&base=EUR')
             ->will($this->returnValue($response));
 
         $this->setExpectedException(UnsupportedCurrencyException::class);

--- a/tests/CurrencyConverterTest/Provider/ExchangeRatesIoTest.php
+++ b/tests/CurrencyConverterTest/Provider/ExchangeRatesIoTest.php
@@ -21,7 +21,7 @@ class ExchangeRatesIoTest extends \PHPUnit_Framework_TestCase
         $httpClient
             ->expects($this->once())
             ->method('get')
-            ->with(ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=USD&base=EUR')
+            ->with('https://' . ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=USD&base=EUR')
             ->will($this->returnValue($response));
         $this->assertEquals(
             1.1645,
@@ -42,7 +42,7 @@ class ExchangeRatesIoTest extends \PHPUnit_Framework_TestCase
         $httpClient
             ->expects($this->once())
             ->method('get')
-            ->with(ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=XXX&base=EUR')
+            ->with('https://' . ExchangeRatesIo::EXCHANGERATESIO_API_BASEPATH . '?symbols=XXX&base=EUR')
             ->will($this->returnValue($response));
 
         $this->setExpectedException(UnsupportedCurrencyException::class);

--- a/tests/CurrencyConverterTest/Provider/FixerApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FixerApiTest.php
@@ -21,11 +21,8 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
         $httpClient = $this->getMock(Client::class);
         $httpClient
             ->expects($this->once())
-            ->method('__call')
-            ->with(
-                'get',
-                ['http://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=USD&base=EUR']
-            )
+            ->method('get')
+            ->with('http://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=USD&base=EUR')
             ->will($this->returnValue($response));
         $this->assertEquals(
             1.1645,
@@ -45,11 +42,8 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
         $httpClient = $this->getMock(Client::class);
         $httpClient
             ->expects($this->once())
-            ->method('__call')
-            ->with(
-                'get',
-                ['http://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=XXX&base=EUR']
-            )
+            ->method('get')
+            ->with('http://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=XXX&base=EUR')
             ->will($this->returnValue($response));
 
         $this->setExpectedException(UnsupportedCurrencyException::class);
@@ -68,11 +62,8 @@ class FixerApiTest extends \PHPUnit_Framework_TestCase
         $httpClient = $this->getMock(Client::class);
         $httpClient
             ->expects($this->once())
-            ->method('__call')
-            ->with(
-                'get',
-                ['https://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=USD&base=EUR']
-            )
+            ->method('get')
+            ->with('https://' . FixerApi::FIXER_API_BASEPATH . '?access_key=SOME-ACCESS-KEY&symbols=USD&base=EUR')
             ->will($this->returnValue($response));
         $this->assertEquals(
             1.1645,

--- a/tests/CurrencyConverterTest/Provider/FranfurterApiTest.php
+++ b/tests/CurrencyConverterTest/Provider/FranfurterApiTest.php
@@ -1,0 +1,105 @@
+<?php
+namespace CurrencyConverter\Provider;
+
+use CurrencyConverter\Exception\UnsupportedCurrencyException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\ResponseInterface;
+
+class FranfurterApiTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetRateWithDefaults()
+    {
+        $response = $this->getMock(ResponseInterface::class);
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue(
+                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-02","rates":{"USD":1.1645}}', 'r'))
+            ));
+        $httpClient = $this->getMock(Client::class);
+        $httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('https://' . FrankfurterApi::DEFAULT_BASEPATH . '?symbols=USD&base=EUR')
+            ->will($this->returnValue($response));
+
+        $provider = new FrankfurterApi();
+        $provider->setHttpClient($httpClient);
+
+        $this->assertEquals(1.1645, $provider->getRate('EUR', 'USD'));
+    }
+
+    public function testGetUnavailableRate()
+    {
+        $response = $this->getMock(ResponseInterface::class);
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue(
+                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-28","rates":{}}', 'r'))
+            ));
+        $httpClient = $this->getMock(Client::class);
+        $httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('https://' . FrankfurterApi::DEFAULT_BASEPATH . '?symbols=XXX&base=EUR')
+            ->will($this->returnValue($response));
+
+        $this->setExpectedException(UnsupportedCurrencyException::class);
+
+        $provider = new FrankfurterApi();
+        $provider->setHttpClient($httpClient);
+        $provider->getRate('EUR', 'XXX');
+    }
+
+    public function dataUrlOptions()
+    {
+        return [
+            [
+                'http://' . FrankfurterApi::DEFAULT_BASEPATH . '?symbols=USD&base=EUR',
+                FrankfurterApi::DEFAULT_BASEPATH,
+                false
+            ],
+            [
+                'https://' . FrankfurterApi::DEFAULT_BASEPATH . '?symbols=USD&base=EUR',
+                FrankfurterApi::DEFAULT_BASEPATH,
+                true
+            ],
+            [
+                'http://my-instance.dev/latest?symbols=USD&base=EUR',
+                'my-instance.dev/latest',
+                false
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataUrlOptions
+     *
+     * @param string $expectedRequestUrl
+     * @param string $basePath
+     * @param boolean $useHttps
+     */
+    public function testGetRate($expectedRequestUrl, $basePath, $useHttps)
+    {
+        $response = $this->getMock(ResponseInterface::class);
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue(
+                new Stream(fopen('data://text/plain,{"base":"EUR","date":"2017-11-02","rates":{"USD":1.1645}}', 'r'))
+            ));
+        $httpClient = $this->getMock(Client::class);
+        $httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with($expectedRequestUrl)
+            ->will($this->returnValue($response));
+
+        $provider = new FrankfurterApi($basePath, $useHttps);
+        $provider->setHttpClient($httpClient);
+
+        $this->assertEquals(1.1645, $provider->getRate('EUR', 'USD'));
+    }
+}


### PR DESCRIPTION
- new provider for the frankfurter api (https://www.frankfurter.app/)
- the base url can be set via constructor to be able to run a private instance of the currency service
- created an abstract implementation for the "fixer api" to be able to re-use it for the two other implementations (somehow all share the same API schema)
- the unit tests were broken for guzzle 7 - i fixed them